### PR TITLE
run.sh update to resolve dns service error

### DIFF
--- a/image/run.sh
+++ b/image/run.sh
@@ -15,4 +15,7 @@ fi
 dbus-daemon --system
 avahi-daemon -D
 
+service dbus start
+service avahi-daemon start
+
 homebridge


### PR DESCRIPTION
I spent a lot of time trying to get homebridge to restart after a shutdown without having to delete the container. For some reason if the container was persistent I would get the "dns service error" on every start. Added a start of dbus and avahi in the run.sh file fixed the issue for me.

Proposing an update of the run.sh file so hopefully others can avoid this error.